### PR TITLE
GhostlyDjangoTestCase: Ensure Ghostly stops even if setUp fails

### DIFF
--- a/ghostly/django/testcase.py
+++ b/ghostly/django/testcase.py
@@ -29,11 +29,8 @@ class GhostlyDjangoTestCase(StaticLiveServerTestCase):
     def setUp(self):
         super(GhostlyDjangoTestCase, self).setUp()
         self.ghostly = Ghostly(self.driver, maximise_window=self.maximise_window)
+        self.addCleanup(self.ghostly.end)
         #self.live_server_url = 'localhost:8000'
-
-    def tearDown(self):
-        super(GhostlyDjangoTestCase, self).tearDown()
-        self.ghostly.end()
 
     def goto(self, url):
         """


### PR DESCRIPTION
When setUp() raises an exception, tearDown() is not called, thus
self.ghostly.end() is never called. Use addCleanup() to register it
instead.
